### PR TITLE
chore: add devcontainer and Docker-based dev/prod setups with pnpm + CI

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "tiptap-dev",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:20",
+  "forwardPorts": [5173],
+  "portsAttributes": { "5173": { "label": "Vite", "onAutoForward": "openBrowser" } },
+  "postCreateCommand": "corepack enable && pnpm install",
+  "postStartCommand": "pnpm --prefix demos run start",
+  "customizations": {
+    "vscode": {
+      "settings": { "git.enableSmartCommit": true },
+      "extensions": [
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint"
+      ]
+    }
+  }
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+**/node_modules
+dist
+demos/dist
+.git
+.devcontainer
+.github
+pnpm-store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+on:
+  push:
+    branches: [ develop, main, master, "**/container**" ]
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  build-node:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+      - name: Enable corepack and install
+        run: |
+          corepack enable
+          pnpm install --no-frozen-lockfile
+      - name: Turbo build
+        run: pnpm turbo run build
+      - name: Build demos
+        run: pnpm --prefix demos run build:demos
+  build-docker:
+    runs-on: ubuntu-latest
+    needs: build-node
+    steps:
+      - uses: actions/checkout@v4
+      - name: Docker build
+        run: docker build -t tiptap-app .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# build
+FROM node:20-alpine AS build
+WORKDIR /app
+# pnpm via Corepack
+RUN corepack enable
+COPY package.json pnpm-lock.yaml* ./
+COPY turbo.json ./
+COPY packages ./packages
+COPY packages-deprecated ./packages-deprecated 2>/dev/null || true
+COPY packages/pm ./packages/pm 2>/dev/null || true
+COPY demos ./demos
+COPY patches ./patches 2>/dev/null || true
+COPY tsconfig.* ./
+COPY .eslintrc.* . 2>/dev/null || true
+RUN pnpm install --no-frozen-lockfile
+# full monorepo build, then demos build
+RUN pnpm turbo run build
+RUN pnpm --prefix demos run build:demos
+
+# serve demos build
+FROM nginx:alpine
+COPY --from=build /app/demos/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.9"
+services:
+  web:
+    image: node:20-alpine
+    working_dir: /repo
+    command: sh -lc "corepack enable && pnpm install --no-frozen-lockfile && pnpm --prefix demos run start"
+    ports:
+      - "5173:5173"
+    volumes:
+      - ./:/repo
+    environment:
+      - HOST=0.0.0.0


### PR DESCRIPTION
Adds `.devcontainer`, `Dockerfile`, `docker-compose.yml`, `.dockerignore`, and CI that builds with pnpm and Turbo.

Development
```
docker compose up
# http://localhost:5173
```

Production
```
docker build -t tiptap-app .
docker run -p 8080:80 tiptap-app
# http://localhost:8080
```

The CI workflow installs dependencies using pnpm, runs `pnpm turbo run build`, builds the `demos` package, and then builds a Docker image to ensure containerization is working.

Please review and merge. Thanks!
